### PR TITLE
[신지원] Sprint3

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,9 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
+    <meta property="og:description" content="일상의 모든 물건을 거래해보세요" />
+    <meta property="og:title" content="판다마켓" />
+    <meta property="og:image" content="logo/panda-market-logo" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>판다마켓</title>
     <link rel="icon" href="logo/favicon.ico" />

--- a/index.html
+++ b/index.html
@@ -3,71 +3,27 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- 브라우저 탭에 표시하고 싶은 제목을 적어주세요. -->
     <title>판다마켓</title>
-    <!-- 
-      웹사이트를 식별하기 위해 브라우저에 표시하는 작은 아이콘을 '파비콘(Favicon)'이라고 합니다. 
-      일반적으로 16x16px의 .ico 확장자로 되어 있고, 온라인에서 favicon generator를 찾아 사용하면 편리하게 이미지를 파비콘으로 전환할 수 있습니다. 
-    -->
     <link rel="icon" href="logo/favicon.ico" />
-    <!-- 외부 폰트 Pretendard의 스타일시트를 링크해 주세요. -->
     <link
       rel="stylesheet"
       as="style"
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
     />
-    <!-- 스타일시트를 링크해 주세요. styles라는 폴더를 만들어 웹사이트 전역에서 공통으로 사용되는 global 스타일링과 각 페이지 별로 특정적인 스타일링을 위한 파일을 나눠 작성하면 가독성을 개선할 수 있어요. -->
     <link rel="stylesheet" href="styles/global.css" />
     <link rel="stylesheet" href="styles/home.css" />
   </head>
 
   <body>
-    <!-- 
-      <header>는 일반적으로 로고, 내비게이션 메뉴, 검색창 등의 요소로 구성됩니다. 
-      내비게이션 메뉴 버튼이 여러 개라면 <nav> 시맨틱 태그로 감싸주어 레이아웃을 명확하게 해주면 좋습니다. 
-    -->
     <header>
-      <!-- 
-        - 로고 클릭 시 홈페이지로 이동. index.html로 이동할 때는 href='/'를 사용하면 됩니다. 
-        - <button>과 <a> 태그 두 가지 모두 사용 가능하지만, 단순한 페이지 간 또는 페이지 내에서의 이동에는 <a> 태그를 사용하고, 클릭 시 특정 이벤트가 발생하는 경우에는 <button> 태그를 사용하는 것이 권장됩니다.
-        (<button>을 사용했다면 커서 유형을 pointer로 바꿔주는 것을 잊지 마세요!)
-      -->
-      <!-- 
-        - 이미지 또한 images 폴더를 만들어 카테고리별로 정리해 주면 좋습니다.
-        - 이미지 최적화: 각 이미지의 특징에 따라 알맞은 형식으로 저장하는 것도 웹사이트의 효율에 영향을 미칩니다. 
-          (1) 벡터 기반의 SVG 파일로 저장하면 확대해도 이미지가 깨지지 않는다는 장점이 있습니다. 로고, 아이콘 등 단순한 그래픽의 경우에는 용량이 매우 작지만, 복잡한 그래픽의 경우 용량이 PNG보다 훨씬 커지는 경우가 있으니 주의하세요.
-          (2) JPG/JPEG는 PNG보다 압축률이 높지만 품질 저하가 발생할 수 있습니다. 복잡한 이미지에 적합하며, 배경 이미지 등에 많이 사용됩니다.
-          (3) 투명한 배경이 필요할 때는 PNG를 많이 사용합니다. 품질 저하 없이 저장이 가능하지만, 용량이 큰 경우가 많아 https://tinypng.com/ 같은 사이트를 이용해 이미지 압축을 한 번 하고 프로젝트에 추가하는 것이 권장됩니다.
-        - 사용자가 화면을 확대하거나 고해상도 화면을 사용할 가능성을 대비해 이미지를 실제 필요한 크기보다 2배수 또는 3배수로 저장하는 경우가 많습니다.
-        - 이미지 삽입할 때 잊지 말고 alt 속성에 이미지를 묘사하는 대체 텍스트를 넣어주세요!
-      -->
       <a href="/"
-        ><img
-          src="logo/panda-market-logo.svg"
-          alt="판다마켓 홈"
-          width="153"
+        ><img src="logo/panda-market-logo.svg" alt="판다마켓 홈" width="153"
       /></a>
-      <!-- 
-        id 이름은 camelCase(단어 연결 시 맨 처음 단어를 제외한 단어들의 첫 글자를 대문자로 표기)로, 
-        class 이름은 kebab-case(단어를 하이픈(-)으로 구분)를 사용하는 것을 권장합니다.
-        하지만 팀마다 선호하는 스타일이 다르기 때문에 naming convention 등 정해진 규칙에 따라 통일성 있게 사용하는 것이 더 중요합니다.
-      -->
-      <!-- 클릭 시 로그인 페이지로 이동. login.html 파일을 생성해 임시 페이지를 만들어 주세요. -->
-      <a href="login.html" id="loginLinkButton" class="button">로그인</a>
+      <a href="signin.html" id="signinLinkButton" class="button">로그인</a>
     </header>
 
-    <!-- 
-      웹페이지의 주요 콘텐츠는 <main> 시맨틱 태그에 넣어주세요. 
-      페이지 내용을 기능 및 특징에 따라 <section>으로 나누어 직관적으로 레이아웃을 살펴볼 수 있도록 구성해 보세요.
-    -->
     <main>
-      <!-- 홈페이지 랜딩 시 가장 상단에 위치해 눈을 사로잡는 역할을 하는 요소를 '히어로 섹션' 또는 '히어로 이미지' 라고 불러요. -->
-      <!-- 
-        전체적인 레이아웃, 디자인, 및 동작성을 먼저 살펴본 후에 비슷한 요소들을 묶어서 개발하면 코드의 재사용성을 높일 수 있어요. 
-        판다마켓 홈페이지에서는 최상단의 히어로 섹션(hero)과 하단 배너 섹션(bottomBanner)의 디자인이 비슷해서 "banner" 클래스로 묶어주었어요. 
-      -->
-      <!-- 각 섹션 내에 컨테이너의 최대 너비를 1200px로 제한하고 화면 중앙에 정렬해 주는 inner wrapper div를 씌워줬어요. -->
       <section id="hero" class="banner">
         <div class="wrapper">
           <h1>
@@ -79,12 +35,7 @@
       </section>
 
       <section id="features" class="wrapper">
-        <!-- features 섹션 내에 비슷한 레이아웃의 요소가 3개 있기 때문에 각 요소에게 feature 라는 클래스명을 부여했어요. -->
         <div class="feature">
-          <!-- 
-            화면 크기에 따라 이미지 사이즈가 자동으로 조정되도록 이미지의 width를 고정된 px값이 아닌 부모 컨테이너의 너비의 50%로 설정해 주었어요. 
-            각 요소의 크기를 설정하는 방식은 반응형 웹 디자인(responsive web design)을 개발할 때 중요한 고려사항이에요.
-          -->
           <img
             src="images/feature1-image.png"
             alt="인기 상품"
@@ -144,15 +95,10 @@
     <footer>
       <div>©codeit - 2024</div>
       <div id="footerMenu">
-        <!-- 클릭 시 약관 및 FAQ 페이지로 이동. privacy.html과 faq.html 파일을 생성해 임시 페이지를 만들어 주세요. -->
         <a href="privacy.html">Privacy Policy</a>
         <a href="faq.html">FAQ</a>
       </div>
       <div id="socialMedia">
-        <!--
-          target="_blank" 속성값을 넣어주어 링크가 새로운 탭에서 열리도록 했어요.
-          새 창에서 하이퍼링크를 열 때에는 보안상 취약점 또는 퍼포먼스 이슈가 발생할 수 있기 때문에 rel="noopener noreferrer" 속성값을 함께 넣어주는 경우가 많습니다.
-        -->
         <a
           href="https://www.facebook.com/"
           target="_blank"

--- a/index.html
+++ b/index.html
@@ -26,53 +26,64 @@
     <main>
       <section id="hero" class="banner">
         <div class="wrapper">
-          <h1>
-            일상의 모든 물건을<br />
-            거래해 보세요
+          <h1 class="wrapperh1 ">
+            <p>일상의 모든 물건을</p>
+            <p> 거래해보세요</p>
           </h1>
           <a href="items.html" class="button pill-button">구경하러 가기</a>
         </div>
       </section>
 
       <section id="features" class="wrapper">
-        <div class="feature">
+        <div class="feature" id="feature1">
           <img
+            class="showimg"
             src="images/feature1-image.png"
             alt="인기 상품"
             width="50%"
           />
           <div class="feature-content">
             <h2 class="feature-tag">Hot item</h2>
-            <h1>인기 상품을<br />확인해 보세요</h1>
+            <h1>
+              <p>인기 상품을</p>
+              <p> 확인해보세요</p>
+            </h1>
             <p class="feature-description">
               가장 HOT한 중고거래 물품을<br />판다마켓에서 확인해 보세요
             </p>
           </div>
         </div>
-        <div class="feature">
+        <div class="feature" id="feature2">
           <div class="feature-content">
             <h2 class="feature-tag">Search</h2>
-            <h1>구매를 원하는<br />상품을 검색하세요</h1>
+            <h1>
+              <p>구매를 원하는</p>
+              <p> 상품을 검색하세요</p>
+            </h1>
             <p class="feature-description">
               구매하고 싶은 물품은 검색해서
               <br />쉽게 찾아보세요
             </p>
           </div>
           <img
+            class="showimg"
             src="images/feature2-image.png"
             alt="검색 기능"
             width="50%"
           />
         </div>
-        <div class="feature">
+        <div class="feature" id="feature3">
           <img
+            class="showimg"
             src="images/feature3-image.png"
             alt="판매 상품 등록"
             width="50%"
           />
           <div class="feature-content">
             <h2 class="feature-tag">Register</h2>
-            <h1>판매를 원하는<br />상품을 등록하세요</h1>
+            <h1>
+              <p>판매를 원하는</p> 
+              <p> 상품을 등록하세요</p>
             <p class="feature-description">
               어떤 물건이든 판매하고 싶은 상품을
               <br />쉽게 등록하세요
@@ -82,11 +93,10 @@
       </section>
 
       <section id="bottomBanner" class="banner">
-        <div class="wrapper">
+        <div class="wrapper" id="wrapperbottom">
           <h1>
-            믿을 수 있는
-            <br />
-            판다마켓 중고거래
+            <p>믿을 수 있는</p>
+            <p>판다마켓 중고거래</p>
           </h1>
         </div>
       </section>
@@ -103,22 +113,23 @@
           href="https://www.facebook.com/"
           target="_blank"
           rel="noopener noreferrer"
-          ><img src="social/facebook-logo.svg" alt="페이스북" width="20"
+          ><img class="footerimg" src="social/facebook-logo.svg" alt="페이스북" width="20"
         /></a>
         <a href="https://twitter.com/" target="_blank" rel="noopener noreferrer"
-          ><img src="social/twitter-logo.svg" alt="트위터" width="20"
+          ><img  class="footerimg" src="social/twitter-logo.svg" alt="트위터" width="20"
         /></a>
         <a
           href="https://www.youtube.com/"
           target="_blank"
           rel="noopener noreferrer"
-          ><img src="social/youtube-logo.svg" alt="유튜브" width="20"
+          ><img class="footerimg" src="social/youtube-logo.svg" alt="유튜브" width="20"
         /></a>
         <a
           href="https://www.instagram.com/"
           target="_blank"
           rel="noopener noreferrer"
           ><img
+            class="footerimg"
             src="social/instagram-logo.svg"
             alt="인스타그램"
             width="20"

--- a/login.html
+++ b/login.html
@@ -11,38 +11,72 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
     />
-    <link rel="stylesheet" href="styles/login.css" />
+    <link rel="stylesheet" href="styles/global.css" />
+    <link rel="stylesheet" href="styles/auth.css" />
   </head>
 
   <body>
-    <header>
-      <a href="/"><img class="logo" src="logo/panda-market-logo.svg" /></a>
-    </header>
-    <main>
-      <form>
-        <div class="email">
-          <label for="user-email">이메일</label>
-          <input type="email" id="user-email" name="user-email" placeholder="이메일을 입력해주세요" />
+    <div class="auth-container">
+      <div class="logo-home-button-wrapper">
+        <a href="/"
+          ><img src="logo/panda-market-logo.svg" alt="판다마켓 홈" width="396"
+        /></a>
+      </div>
+
+      <form method="post">
+        <div class="input-item">
+          <label for="email">이메일</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="이메일을 입력해 주세요"
+          />
         </div>
-        <div class="pw">
+        <div class="input-item">
           <label for="password">비밀번호</label>
-          <div class="pweye">
-            <input type="password" id="password" name="password" placeholder="비밀번호를 입력해주세요" />    
-            <img class="eyeclose" src="logo/eyeclose.svg" />
+          <div class="input-wrapper">
+            <input
+              id="password"
+              name="password"
+              type="password"
+              placeholder="비밀번호를 입력해 주세요"
+            />
+            <img
+              src="logo/eyeclose.svg"
+              alt="비밀번호 숨김"
+              class="toggle-password"
+            />
           </div>
         </div>
-        <a href="/login.html"><button>로그인</button></a>
+
+        <button type="submit" class="button pill-button full-width">
+          로그인
+        </button>
       </form>
-      <div class="easy-login"> 
-        <p class="info">간편 로그인하기</p>
-        <div class="site-logo">
-          <a href="https://www.google.com/"><img src="social/googlelogo.svg" /></a>
-          <a href="https://www.kakaocorp.com/page/"><img src="social/kakaologo.svg" /></a>
+
+      <div class="social-login-container">
+        <h3>간편 로그인하기</h3>
+        <div class="social-login-buttons-container">
+          <a href="https://www.google.com/" target="_blank"
+            ><img
+              src="social/googlelogo.svg"
+              alt="구글 로그인"
+              width="42"
+          /></a>
+          <a href="https://www.kakaocorp.com/page/" target="_blank"
+            ><img
+              src="social/kakaologo.svg"
+              alt="카카오톡 로그인"
+              width="42"
+          /></a>
         </div>
       </div>
-      <div class="ask-signup"> 
-        <p class="ask">판다마켓이 처음이신가요? <a class="signup" href="signup.html">회원가입</a></p>
+
+      <div class="auth-switch">
+        판다마켓이 처음이신가요? <a href="signup.html">회원가입</a>
       </div>
-    </main>
+    </div>
   </body>
 </html>
+

--- a/signup.html
+++ b/signup.html
@@ -11,49 +11,96 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
     />
-    <link rel="stylesheet" href="styles/signup.css" />
+    <link rel="stylesheet" href="styles/global.css" />
+    <link rel="stylesheet" href="styles/auth.css" />
   </head>
 
   <body>
-    <header>
-      <a href="/"><img class="logo" src="logo/panda-market-logo.svg" /></a>
-    </header>
-    <main>
-      <form>
-        <div class="email">
-          <label for="user-email">이메일</label>
-          <input type="email" id="user-email" name="user-email" placeholder="이메일을 입력해주세요" />
+    <div class="auth-container">
+      <div class="logo-home-button-wrapper">
+        <a href="/"
+          ><img src="logo/panda-market-logo.svg" alt="판다마켓 홈" width="396"
+        /></a>
+      </div>
+
+      <form method="post">
+        <div class="input-item">
+          <label for="email">이메일</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="이메일을 입력해 주세요"
+          />
         </div>
-        <div class="nickname"> 
-          <label for="user-name">닉네임</label>
-          <input id="user-name" name="user-name" placeholder="닉네임을 입력해주세요" />
+        <div class="input-item">
+          <label for="nickname">닉네임</label>
+          <input
+            id="nickname"
+            name="nickname"
+            type="text"
+            placeholder="닉네임을 입력해 주세요"
+          />
         </div>
-        <div class="pw">
+        <div class="input-item">
           <label for="password">비밀번호</label>
-          <div class="pweye">
-            <input type="password" id="password" name="password" placeholder="비밀번호를 입력해주세요" />
-            <img class="eyeclose" src="logo/eyeclose.svg" />
+          <div class="input-wrapper">
+            <input
+              id="password"
+              name="password"
+              type="password"
+              placeholder="비밀번호를 입력해 주세요"
+            />
+            <img
+              src="logo/eyeclose.svg"
+              alt="비밀번호 숨김"
+              class="toggle-password"
+            />
           </div>
         </div>
-        <div class="checkpw"> 
-          <label for="pwcheck">비밀번호 확인</label>
-          <div class="pweye">
-            <input type="password" id="pwcheck" name="pwcheck" placeholder="비밀번호를 다시 한 번 입력해주세요" />
-            <img class="eyeclose" src="logo/eyeclose.svg" />
+        <div class="input-item">
+          <label for="passwordConfirmation">비밀번호 확인</label>
+          <div class="input-wrapper">
+            <input
+              id="passwordConfirmation"
+              name="passwordConfirmation"
+              type="password"
+              placeholder="비밀번호를 다시 한 번 입력해 주세요"
+            />
+            <img
+              src="logo/eyeclose.svg"
+              alt="비밀번호 숨김"
+              class="toggle-password"
+            />
           </div>
         </div>
-        <a href="/signup"><button>회원가입</button></a>
+
+        <button type="submit" class="button pill-button full-width">
+          회원가입
+        </button>
       </form>
-      <div class="easy-login"> 
-        <p class="info">간편 로그인하기</p>
-        <div class="site-logo">
-          <a href="https://www.google.com/"><img src="social/googlelogo.svg" /></a>
-          <a href="https://www.kakaocorp.com/page/"><img src="social/kakaologo.svg" /></a>
+
+      <div class="social-login-container">
+        <h3>간편 로그인하기</h3>
+        <div class="social-login-buttons-container">
+          <a href="https://www.google.com/" target="_blank"
+            ><img
+              src="social/googlelogo.svg"
+              alt="구글 로그인"
+              width="42"
+          /></a>
+          <a href="https://www.kakaocorp.com/page/" target="_blank"
+            ><img
+              src="social/kakaologo.svg"
+              alt="카카오톡 로그인"
+              width="42"
+          /></a>
         </div>
       </div>
-      <div class="ask-login"> 
-        <p class="ask">이미 회원이신가요? <a class="signup" href="login.html">로그인</a></p>
+
+      <div class="auth-switch">
+        이미 회원이신가요? <a href="login.html">로그인</a>
       </div>
-    </main>
+    </div>
   </body>
 </html>

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -1,0 +1,89 @@
+.auth-container {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.logo-home-button-wrapper {
+  display: block;
+  text-align: center;
+  margin-top: 60px;
+  margin-bottom: 40px;
+}
+
+.input-item {
+  margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+}
+
+label {
+  display: block;
+  margin-bottom: 16px;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+input {
+  padding: 16px 24px;
+  background-color: #f3f4f6;
+  border: none;
+  border-radius: 12px;
+  font-size: 16px;
+  line-height: 24px;
+  width: 100%;
+}
+
+input::placeholder {
+  color: #9ca3af;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+input:focus {
+  outline-color: var(--blue);
+}
+
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.toggle-password {
+  position: absolute;
+  right: 24px;
+  cursor: pointer;
+}
+
+.social-login-container {
+  background-color: #e6f2ff;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 23px;
+  margin: 24px 0;
+}
+
+.social-login-container h3 {
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.social-login-buttons-container {
+  display: flex;
+  gap: 16px;
+}
+
+.auth-switch {
+  font-weight: 500;
+  font-size: 15px;
+  text-align: center;
+}
+
+.auth-switch a {
+  color: #3182f6;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,7 +1,17 @@
-/* 
-  전체 선택자(*) 및 a, button, img 태그에 대한 CSS는 새로운 웹 개발 프로젝트를 시작할 때 전역 스타일에 기본적으로 넣어주면 좋은 내용들입니다. 
-  브라우저 간의 스타일 차이를 최소화하고 예측 가능한 레이아웃을 위해 브라우저 기본 세팅을 일부 리셋해 준다고 생각하면 됩니다. 
-*/
+:root {
+  /* Gray scale */
+  --gray-900: #1b1d1f;
+  --gray-800: #26282b;
+  --gray-600: #454c53;
+  --gray-500: #72787f;
+  --gray-400: #9ea4a8;
+  --gray-200: #e5e7eb;
+  --gray-100: #e8ebed;
+  --gray-50: #f7f7f8;
+
+  /* Primary color */
+  --blue: #3692ff;
+}
 
 * {
   margin: 0;
@@ -9,52 +19,28 @@
   box-sizing: border-box;
 }
 
-/* 링크가 상위 요소 또는 설정된 기본 텍스트 색상과 동일하게 표현되길 원한다면 a 태그에 명시적으로 color: inherit을 지정해 줘야 합니다. */
-a {
-  text-decoration: none;
-  color: inherit;
-}
-
-button {
-  background: none;
-  border: none;
-  outline: none;
-  box-shadow: none;
-  cursor: pointer;
-}
-
-/* 
-  - 이미지는 기본적으로 inline 요소로 취급되기 때문에 텍스트의 baseline에 맞춰서 정렬됩니다. 
-    브라우저가 이미지를 텍스트와 같은 라인에 배치할 때 g, j, p 등 아래로 치우치는 알파벳의 descender 공간을 예약해 놓기 때문에 이미지와 주변 텍스트 사이에 의도하지 않은 작은 간격이 생기는 경우가 많습니다. 
-    <img> 태그에 vertical-align: bottom;을 설정해 주면 이미지가 텍스트 라인의 가장 아래쪽에 맞춰서 정렬되어, 불필요한 공간 없이 배치할 수 있습니다.
-  - 전역적으로 <img>의 display 유형을 inline이 아닌 block으로 바꿔 해당 이슈를 해결하는 경우도 있습니다.
-*/
-img {
-  vertical-align: bottom;
-}
-
-/* 
-  프로젝트 전체에 일관된 텍스트 스타일을 적용합니다. 
-  word-break: keep-all 속성을 사용하면 띄어쓰기를 기준으로 줄바꿈하도록 설정하여 어절 기반의 한국어 특성에 적합한 읽기 편한 레이아웃을 제공할 수 있습니다.
-*/
 body {
   color: #374151;
   word-break: keep-all;
   font-family: "Pretendard", sans-serif;
 }
 
-/* 여러 요소가 나란히 배열되어 있을 때는 티가 나지 않아 보여도 항상 잊지 말고 display: flex; align-items: center;로 세로 중앙 정렬을 맞춰주세요. */
 header {
+  position: fixed;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 70px;
   display: flex;
-  position: sticky;
-  top: 0;
   justify-content: space-between;
   align-items: center;
   padding: 0 200px;
   background-color: #ffffff;
   border-bottom: 1px solid #dfdfdf;
+}
+
+main {
+  margin-top: 70px;
 }
 
 footer {
@@ -70,7 +56,7 @@ footer {
 #footerMenu {
   display: flex;
   gap: 30px;
-  color: #e5e7eb;
+  color: var(--gray-200);
 }
 
 #socialMedia {
@@ -78,7 +64,15 @@ footer {
   gap: 12px;
 }
 
-/* 요소의 최대 너비를 1200px로 제한하고, 요소가 그보다 큰 경우에는 가로 중앙 정렬해 주는 inner container */
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+img {
+  vertical-align: bottom;
+}
+
 .wrapper {
   max-width: 1200px;
   margin: 0 auto;
@@ -92,19 +86,29 @@ h1 {
   letter-spacing: 0.02em;
 }
 
-/* 위에서 스타일링해준 <button> 태그와 달리 버튼 모양이지만 <a> 태그를 사용한 class='button' 요소들을 지칭하는 부분이니 혼동하지 않도록 주의하세요. */
+button {
+  background: none;
+  border: none;
+  outline: none;
+  box-shadow: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  color: inherit;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
 .button {
-  background-color: #3692ff;
+  background-color: var(--blue);
   color: #ffffff;
   display: inline-flex;
   align-items: center;
   justify-content: center;
 }
 
-/* 
-  가상 클래스(pseudo-class)를 사용해 특정 상태에 맞는 스타일을 적용하세요. 
-  버튼 역할을 하는 요소에는 hover 또는 disabled 시의 스타일을 지정해 주는 것이 사용자 경험에 도움이 됩니다. 
-*/
 .button:hover {
   background-color: #1967d6;
 }
@@ -119,14 +123,13 @@ h1 {
   pointer-events: none;
 }
 
-/* 
-  - 알약 모양의 버튼을 'pill button'이라고 부릅니다. 
-  - border-radius에 큰 값을 넣어주면 모서리가 원형으로 둥글려지는 효과가 있습니다. 
-  - 고정된 width나 height을 부여하는 것보다 내부 콘텐츠에 padding을 적용해서 요소의 전체 크기를 유동적으로 조정하는 방법이 반응형 웹 디자인과 접근성(accessibility) 측면에서 더 적합합니다.
-*/
 .pill-button {
   font-size: 20px;
   font-weight: 700;
   border-radius: 999px;
-  padding: 16px 124px;
+  padding: 16px 126px;
+}
+
+.full-width {
+  width: 100%;
 }

--- a/styles/home.css
+++ b/styles/home.css
@@ -20,20 +20,17 @@
   background-image: url("../images/bottom-banner-image.png");
 }
 
-/* 버튼 등의 요소에 고정된 width나 height을 부여하는 것보다 내부 콘텐츠에 padding을 적용해서 요소의 전체 크기를 유동적으로 조정하는 방법이 반응형 웹 디자인과 접근성(accessibility) 측면에서 더 적합합니다. */
-#loginLinkButton {
+#signinLinkButton {
   font-size: 16px;
   font-weight: 600;
   border-radius: 8px;
-  padding: 11.5px 23px;
+  padding: 14.5px 43px;
 }
 
-/* banner 요소 내의 pill-button을 선택해 스타일 적용. ID 선택자 대신 이렇게 캐스캐이딩을 활용하는 방법은 특정 컨텍스트 내에서만 스타일을 적용하고자 할 때 유용해요. */
 .banner .pill-button {
   margin-top: 32px;
 }
 
-/* flex 요소에서는 gap 속성을 사용해 자식 요소 사이의 간격을 조정할 수 있어요. */
 .feature {
   padding: 138px 0;
   display: flex;
@@ -41,18 +38,16 @@
   gap: 5%;
 }
 
-/* pseudo-selector인 nth-child(2)를 통해 feature 클래스를 가진 요소 중 두 번째 아이템에만 다른 스타일을 적용했어요. */
 .feature:nth-child(2) {
   text-align: right;
 }
 
-/* flex: 1을 통해 부모 요소인 feature의 남은 공간을 모두 차지하도록 설정할 수 있어요. */
 .feature-content {
   flex: 1;
 }
 
 .feature-tag {
-  color: #3692ff;
+  color: var(--blue);
   font-size: 18px;
   line-height: 25px;
   font-weight: 700;
@@ -65,4 +60,12 @@
   line-height: 120%;
   letter-spacing: 0.08em;
   margin-top: 24px;
+}
+/**태블릿**/
+@media (min-width: 768px) { 
+
+}
+/**모바일**/
+@media (min-width: 375px) { 
+
 }

--- a/styles/home.css
+++ b/styles/home.css
@@ -62,10 +62,89 @@
   margin-top: 24px;
 }
 /**태블릿**/
-@media (min-width: 768px) { 
+@media (min-width: 768px) and (max-width: 1199px){ 
 
+  header { 
+    padding: 0 24px;
+  }
+
+  .banner { 
+    height: 771px;
+    background-size: 120%;
+    background-position-x: 50%;
+  }
+
+  div.wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  #bottomBanner h1 { 
+    text-align: center;
+  }
+
+  .wrapperh1 { 
+    font-size: 40px;
+    line-height: 56px;
+    display: flex;
+    white-space: pre;
+  }
+  
+  #feauture1 { 
+    margin-bottom: 64px;  /** <section id="features" class="wrapper"> 이 부분 간격을
+                              주려고 했는데 왜 되질 않는지 모르겠습니다... **/
+  }
+
+  .feature h1 { 
+    display: flex;
+    white-space: pre;
+  }
+
+  #features { 
+    padding-top: 24px;
+    padding-bottom: 80px;
+  }
+
+  .showimg { 
+    width: 100%;
+    padding: 0 24px;
+  }
+
+  div.feature { 
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+  }
+
+  .feature-content { 
+    margin-top: 20px;
+    text-align: left;
+  }
+
+  #bottomBanner { 
+    height: 927px;
+    background-size: 110%;
+    background-position-x: 50%;
+  }
+
+  #wrapperbottom { 
+    margin-bottom: 201px;
+  }
+
+  footer{ 
+    padding: 32px 104px 108px 104px;
+  }
+
+  .footerimg { 
+    width: 20px;
+    height: 20px;
+  }
 }
 /**모바일**/
-@media (min-width: 375px) { 
-
+@media (min-width: 375px) and (max-width: 767px){ 
+  header { 
+    padding: 0 16px;
+  }
 }

--- a/styles/signup.css
+++ b/styles/signup.css
@@ -1,24 +1,53 @@
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+
 * { 
   box-sizing: border-box;
   font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Pretendard Variable", Pretendard, Roboto, "Noto Sans KR", "Segoe UI", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+header { 
+  text-align: center;
 }
 
 .logo { 
-  width: 396px;
   height: 132px;
-  margin: 60px 762px;
+}
+
+.alogo { 
+  margin-bottom: 40px;
 }
 
 main { 
   width: 640px;
   height: 664px;
-  margin: 0 640px;
+  margin: 0 auto;
   gap: 24px;
 }
 
 form { 
   height: 524px;
-  gap: 24px;
+  row-gap: 24px;
   display: flex;
   flex-direction: column;
   justify-content: space-around;
@@ -109,7 +138,6 @@ button {
   width: 640px;
   height: 56px;
   border-radius: 40px;
-  padding: 16px 124px 16px 124px;
   gap: 10px;
   color: #ffffff;
   font-size: 20px;
@@ -152,7 +180,6 @@ button {
 .site-logo { 
   display: flex;
   justify-content: space-between;
-  width: 100px;
   height: 42px;
   gap: 16px;
 }
@@ -160,4 +187,5 @@ button {
 .ask-login { 
   display: flex;
   justify-content: center;
+  margin-top: 24px;
 }


### PR DESCRIPTION
## 요구사항
- [x] Github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
- [x] 피그마 디자인에 맞게 페이지를 만들어 주세요.
- [x] React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.
### 기본

- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
- [x] PC: 1200px 이상
- [x] Tablet: 768px 이상 ~ 1199px 이하
- [x] Mobile: 375px 이상 ~ 767px 이하
- [x] 375px 미만 사이즈의 디자인은 고려하지 않습니다
- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.
- [ ] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [ ] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [ ] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

### 심화

- [ ] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [x] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [ ] 주소와 이미지는 자유롭게 설정하세요.

## 주요 변경사항

-
-

## 스크린샷

![image](이미지url)

## 멘토에게

- sprint2 템플릿 코드를 사용하였습니다. 
- 태블릿 사이즈 구현중 배너와 바텀배너부분 텍스트들 위치 조정이 잘 안됩니다... align-items로 해도 포지션을 줘도 원하는 위치로 구현이 안됩니다...
-  css코드 주석에 썼듯 메인 내용 부분 간격을 어떻게 줄 지를 잘 모르겠습니다...
- Register부분만 왜 저렇게 화면이 넘어가는지 잘 모르겠습니다..
- 전체적으로 잘 안되는 것 같아서 리뷰 받은 후 모바일 사이즈 구현을 해보겠습니다..!
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
