### PR TITLE
[송효정] Sprint3

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,15 +3,15 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>판다마켓</title>
-		<link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
-		<link rel="stylesheet" href="./src/css/reset.css" />
-		<link rel="stylesheet" href="./src/css/global.css" />
-		<link rel="stylesheet" href="./src/css/home.css" />
+		<link rel="stylesheet" rel="preload" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
+		<link rel="stylesheet" href="/src/css/reset.css" />
+		<link rel="stylesheet" href="/src/css/global.css" />
+		<link rel="stylesheet" href="/src/css/home.css" />
 	</head>
 	<body>
 		<header>
 			<nav class="gnb">
-				<a href="/" class="logo"><img src="./src/img/common/logo_small.png" alt="판다마켓" /></a>
+				<a href="/" class="logo"><img src="/src/img/common/logo_small.png" alt="판다마켓" /></a>
 				<a href="/login" class="btn btn_small">로그인</a>
 			</nav>
 		</header>
@@ -19,14 +19,14 @@
 		<main>
 			<section class="hero">
 				<div class="inner">
-					<img src="./src/img/main/img_home_top.png" alt="인사하는 판다 일러스트" />
+					<img src="/src/img/main/img_home_top.png" alt="인사하는 판다 일러스트" />
 					<h1>일상의 모든 물건을 <br />거래해 보세요</h1>
 					<a class="btn btn_large" href="/items">구경하러 가기</a>
 				</div>
 			</section>
 			<div class="wrapper">
 				<section class="inner">
-					<img src="./src/img/main/img_home_01.png" alt="물건을 구경하는 판다 일러스트" />
+					<img src="/src/img/main/img_home_01.png" alt="물건을 구경하는 판다 일러스트" />
 					<div class="desc">
 						<h2>
 							<span>Hot item</span>
@@ -36,7 +36,7 @@
 					</div>
 				</section>
 				<section class="inner">
-					<img src="./src/img/main/img_home_02.png" alt="돋보기 일러스트" />
+					<img src="/src/img/main/img_home_02.png" alt="돋보기 일러스트" />
 					<div class="desc">
 						<h2>
 							<span>Search</span>
@@ -46,7 +46,7 @@
 					</div>
 				</section>
 				<section class="inner">
-					<img src="./src/img/main/img_home_03.png" alt="카테고리 일러스트" />
+					<img src="/src/img/main/img_home_03.png" alt="카테고리 일러스트" />
 					<div class="desc">
 						<h2>
 							<span>Register</span>
@@ -66,7 +66,7 @@
 					</div>
 				</div>
 
-				<img src="./src/img/main/img_home_bottom.png" alt="대화하는 판다 일러스트" />
+				<img src="/src/img/main/img_home_bottom.png" alt="대화하는 판다 일러스트" />
 			</div>
 		</main>
 		<footer>

--- a/login/index.html
+++ b/login/index.html
@@ -2,8 +2,8 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>판다마켓</title>
-		<link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
+		<title>판다마켓 : 로그인</title>
+		<link rel="stylesheet" rel="preload" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
 		<link rel="stylesheet" href="/src/css/reset.css" />
 		<link rel="stylesheet" href="/src/css/global.css" />
 		<link rel="stylesheet" href="/src/css/login.css" />
@@ -11,20 +11,20 @@
 	<body>
 		<div class="logo">
 			<a href="/">
-				<img src="../src/img/common/logo.png" alt="판다마켓" width="396" />
+				<img src="/src/img/common/logo.png" alt="판다마켓 로고" />
 			</a>
 		</div>
 		<main>
 			<div class="wrapper">
 				<form action="">
 					<label for="loginEmail">이메일</label>
-					<input type="email" id="loginEmail" placeholder="이메일을 입력해주세요" />
+					<input class="text_input" type="email" id="loginEmail" placeholder="이메일을 입력해주세요" />
 					<label for="loginPW">비밀번호</label>
 					<div class="input_wrapper">
-						<input type="password" id="signUpPW" placeholder="비밀번호를 입력해주세요" />
+						<input class="text_input" type="password" id="signUpPW" placeholder="비밀번호를 입력해주세요" />
 						<button class="btn_visibility open">
-							<img class="visibility_close" src="../src/img/login/btn_visibility_close.svg" alt="비밀번호 숨기기" />
-							<img class="visibility_open" src="../src/img/login/btn_visibility_open.svg" alt="비밀번호 보이기" />
+							<img class="visibility_close" src="/src/img/login/btn_visibility_close.svg" alt="비밀번호 숨기기" />
+							<img class="visibility_open" src="/src/img/login/btn_visibility_open.svg" alt="비밀번호 보이기" />
 						</button>
 					</div>
 					<button id="btnLogin" class="btn btn_large">로그인</button>
@@ -34,12 +34,12 @@
 					<ul>
 						<li>
 							<a href="https://www.google.com/" target="_blank" rel="noopener noreferrer">
-								<img src="../src/img/login/social_login_google.png" alt="구글 간편 로그인" />
+								<img src="/src/img/login/social_login_google.png" alt="구글 간편 로그인" />
 							</a>
 						</li>
 						<li>
 							<a href="https://www.kakaocorp.com/page/" target="_blank" rel="noopener noreferrer">
-								<img src="../src/img/login/social_login_kakao.png" alt="카카오톡 간편 로그인" />
+								<img src="/src/img/login/social_login_kakao.png" alt="카카오톡 간편 로그인" />
 							</a>
 						</li>
 					</ul>

--- a/signup/index.html
+++ b/signup/index.html
@@ -2,8 +2,8 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>판다마켓</title>
-		<link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
+		<title>판다마켓 : 회원가입</title>
+		<link rel="stylesheet" rel="preload" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
 		<link rel="stylesheet" href="/src/css/reset.css" />
 		<link rel="stylesheet" href="/src/css/global.css" />
 		<link rel="stylesheet" href="/src/css/login.css" />
@@ -11,28 +11,28 @@
 	<body>
 		<div class="logo">
 			<a href="/">
-				<img src="../src/img/common/logo.png" alt="판다마켓" width="396" />
+				<img src="/src/img/common/logo.png" alt="판다마켓 로고" />
 			</a>
 		</div>
 		<main>
 			<div class="wrapper">
 				<form action="">
 					<label for="signupEmail">이메일</label>
-					<input type="email" id="signupEmail" placeholder="이메일을 입력해주세요" />
+					<input class="text_input" type="email" id="signupEmail" placeholder="이메일을 입력해주세요" />
 					<label for="signUpPW">비밀번호</label>
 					<div class="input_wrapper">
 						<input type="password" id="signUpPW" placeholder="비밀번호를 입력해주세요" />
 						<button class="btn_visibility close">
-							<img src="../src/img/login/btn_visibility_close.svg" alt="비밀번호 숨기기" />
-							<img src="../src/img/login/btn_visibility_open.svg" alt="비밀번호 보이기" visibility="hidden" />
+							<img src="/src/img/login/btn_visibility_close.svg" alt="비밀번호 숨기기" />
+							<img src="/src/img/login/btn_visibility_open.svg" alt="비밀번호 보이기" visibility="hidden" />
 						</button>
 					</div>
 					<label for="signUpPWCheck">비밀번호 확인</label>
 					<div class="input_wrapper">
-						<input type="text" id="signUpPWCheck" placeholder="비밀번호를 다시 한 번 입력해주세요" />
+						<input class="text_input" type="text" id="signUpPWCheck" placeholder="비밀번호를 다시 한 번 입력해주세요" />
 						<button class="btn_visibility close">
-							<img class="visibility_close" src="../src/img/login/btn_visibility_close.svg" alt="비밀번호 숨기기" />
-							<img class="visibility_open" src="../src/img/login/btn_visibility_open.svg" alt="비밀번호 보이기" />
+							<img class="visibility_close" src="/src/img/login/btn_visibility_close.svg" alt="비밀번호 숨기기" />
+							<img class="visibility_open" src="/src/img/login/btn_visibility_open.svg" alt="비밀번호 보이기" />
 						</button>
 					</div>
 					<button id="btnLogin" class="btn btn_large">회원가입</button>
@@ -42,12 +42,12 @@
 					<ul>
 						<li>
 							<a href="https://www.google.com/" target="_blank" rel="noopener noreferrer">
-								<img src="../src/img/login/social_login_google.png" alt="구글 간편 로그인" />
+								<img src="/src/img/login/social_login_google.png" alt="구글 간편 로그인 링크" />
 							</a>
 						</li>
 						<li>
 							<a href="https://www.kakaocorp.com/page/" target="_blank" rel="noopener noreferrer">
-								<img src="../src/img/login/social_login_kakao.png" alt="카카오톡 간편 로그인" />
+								<img src="/src/img/login/social_login_kakao.png" alt="카카오톡 간편 로그인 링크" />
 							</a>
 						</li>
 					</ul>

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -16,6 +16,7 @@
 
 body {
 	overflow-x: hidden;
+	font-family: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
 }
 
 /* common */
@@ -33,12 +34,14 @@ header {
 	height: 70px;
 	display: flex;
 	justify-content: space-between;
-	max-width: 1520px;
 	margin: 0;
 	align-items: center;
 	position: fixed;
+	top: 0;
+	left: 0;
 	z-index: 2;
 	padding: 0 200px;
+	background-color: var(--white);
 }
 
 /* button default style */
@@ -76,7 +79,7 @@ header {
 .input_wrapper {
 	position: relative;
 }
-input {
+.text_input {
 	display: block;
 	background-color: var(--gray100);
 	border: 0;
@@ -89,13 +92,13 @@ input {
 	line-height: 24px;
 }
 
-input:focus {
+.text_input:focus {
 	outline-color: var(--blue);
 	/* border-color: 
 	border-color:red; */
 }
 
-input::placeholder {
+.text_input::placeholder {
 	color: var(--gray400);
 }
 .btn_visibility {
@@ -128,4 +131,10 @@ label {
 	font-size: 18px;
 	line-height: 21.8px;
 	margin: 24px 0 14px;
+}
+
+@media (max-width: 1199px) {
+	.gnb {
+		padding: 0 24px;
+	}
 }

--- a/src/css/home.css
+++ b/src/css/home.css
@@ -1,3 +1,16 @@
+body::after {
+	content: '';
+	height: 4076px;
+	background-image: url('/src/img/tablet.png');
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	opacity: 0.2;
+	pointer-events: none;
+}
+
 .hero {
 	height: 540px;
 	background: var(--skyblue);
@@ -12,11 +25,11 @@
 	gap: 32px;
 }
 .hero h1 {
-	font-family: Pretendard;
 	font-size: 40px;
 	font-weight: 700;
 	line-height: 56px;
 	text-align: left;
+	letter-spacing: -0.03em;
 }
 .hero img {
 	position: absolute;
@@ -113,4 +126,63 @@ footer a {
 
 footer .sns {
 	gap: 12px;
+}
+
+/* responsive */
+@media (max-width: 1199px) {
+	.wrapper > section.inner {
+		/* max-width: 696px; */
+		padding-left: 24px;
+		padding-right: 24px;
+		padding: 24px;
+	}
+	.wrapper > section.inner > img {
+		width: 100%;
+	}
+	.hero {
+		height: 770px;
+	}
+	.hero .inner {
+		justify-content: flex-start;
+	}
+	.hero h1 {
+		text-align: center;
+		margin-top: 84px;
+	}
+	.hero h1 br {
+		display: none;
+	}
+	.hero .btn_large {
+		margin: 0 auto;
+	}
+
+	.hero img {
+		transform: translateX(-50%);
+	}
+
+	.wrapper .desc {
+		margin: 24px 0;
+	}
+
+	.wrapper .desc h2 br {
+		display: none;
+	}
+
+	.banner {
+		height: 928px;
+		overflow: hidden;
+	}
+	.banner .desc {
+		display: block;
+		text-align: center;
+		margin-top: 200px;
+		overflow: hidden;
+	}
+	.banner img {
+		width: 132%;
+		max-width: 996px;
+		height: auto;
+
+		transform: translateX(-50%);
+	}
 }


### PR DESCRIPTION
## 요구사항
### 스프린트 미션2 수정 사항

- [x]  gnb max-width속성 제외
- [x]  gnb background-color
- [x]  상대경로 → 절대경로
- [x]  개별 페이지 별도 타이틀 주기 ex)판다마켓: 로그인
- [x]  img 태그에서 width 삭제
- [x]  css input말고 별도 클래스 사용
- [x]  position:fixed top:0, left:0 도 설정

### 멘토링 추가 사항

- [x]  css preload
- [x]  가변폰트 적용 및 폰트 로딩 최적화 : pretendard variable
- [x]  대체텍스트 자세하게 쓰기

### 스프린트 미션3 구현 사항

**공통**

- 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
    - [x] PC: `1200px` 이상
    - [ ] Tablet: `768px` 이상 ~ `1199px` 이하
    - [ ] Mobile: `375px` 이상 ~ `767px` 이하
    - `375px` 미만 사이즈의 디자인은 고려하지 않습니다

**랜딩 페이지**

- [ ] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 `24px`, “로그인” 버튼 오른쪽 여백 `24px`을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [ ] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 `16px`, “로그인” 버튼 오른쪽 여백 `16px`을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [ ] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

**로그인, 회원가입 페이지 공통**

- [ ] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [ ] Mobile 사이즈에서 좌우 여백 `16px` 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [ ] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 `400px`을 넘지 않습니다.

## **체크리스트 [심화]**

- [ ] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [ ] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [ ] 주소와 이미지는 자유롭게 설정하세요.



## 스크린샷

![image](이미지url)

## 멘토에게

-
-
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
