### PR TITLE
[최주혁] sprint4-2

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -35,7 +35,13 @@
 	--footer-height: 160px;
 
 	--width-minimum: 320px;
-	--width-FHD: var(--width-FHD);
+	--width-FHD: 1920px;
+
+	--size-xs: 320px;
+	--size-sm: 540px;
+	--size-md: 768px;
+	--size-lg: 1080px;
+	--size-xl: 1280px;
 
 	--font-family: 'Pretendard', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
 }

--- a/assets/js/changeInputState.js
+++ b/assets/js/changeInputState.js
@@ -5,16 +5,16 @@ export default function changeInputState(target, state, msg, className) {
 	const preState = classList.contains(className);
 
 	/** 초기화 */
-	function initial() {
+	function initializeInputState() {
 		if (descText) descText.remove();
 		if (preState) classList.remove(className);
 	}
 
 	/** 변경 */
-	function change() {
+	function updateInputState() {
 		if (!descText) {
 			const p = document.createElement('p');
-			p.classList.add(`${className}`);
+			p.classList.add(className);
 			p.textContent = msg;
 			parent.append(p);
 		} else {
@@ -23,6 +23,6 @@ export default function changeInputState(target, state, msg, className) {
 		if (!preState) classList.add(className);
 	}
 
-	if (state) change();
-	else initial();
+	if (state) updateInputState();
+	else initializeInputState();
 }

--- a/assets/js/isEmpty.js
+++ b/assets/js/isEmpty.js
@@ -1,0 +1,2 @@
+/** 값이 비었는지 확인 */
+export const isEmpty = (value) => value === undefined || value === '';

--- a/assets/js/sign/validate/input/validateEmail.js
+++ b/assets/js/sign/validate/input/validateEmail.js
@@ -1,7 +1,13 @@
+const ERROR_MASSAGES = {
+	empty: '이메일을 입력해주세요.',
+	invalidFormat: '잘못된 이메일 형식입니다.',
+};
+
+const EMAIL_PATTERN = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+$/;
+
 /** 이메일 유효성 검사 */
 export default function validateEmail({ empty, value }) {
-	const pattern = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
-	if (empty) return ['error', '이메일을 입력해주세요.'];
-	else if (!pattern.test(value)) return ['error', '잘못된 이메일 형식입니다.'];
+	if (empty) return ['error', ERROR_MASSAGES.empty];
+	else if (!EMAIL_PATTERN.test(value)) return ['error', ERROR_MASSAGES.invalidFormat];
 	else return [null, null];
 }

--- a/assets/js/sign/validate/input/validateNickname.js
+++ b/assets/js/sign/validate/input/validateNickname.js
@@ -1,5 +1,9 @@
+const ERROR_MASSAGES = {
+	empty: '닉네임을 입력해주세요.',
+};
+
 /** 닉네임 유효성 검사 */
 export default function validateNickname({ empty }) {
-	if (empty) return ['error', '닉네임을 입력해주세요.'];
+	if (empty) return ['error', ERROR_MASSAGES.empty];
 	else return [null, null];
 }

--- a/assets/js/sign/validate/input/validatePassword.js
+++ b/assets/js/sign/validate/input/validatePassword.js
@@ -1,6 +1,11 @@
+const ERROR_MASSAGES = {
+	empty: '비밀번호를 입력해주세요.',
+	invalidFormat: '비밀번호를 8자 이상 입력해주세요.',
+};
+
 /** 비밀번호 유효성 검사 */
 export default function validatePassword({ empty, value }) {
-	if (empty) return ['error', '비밀번호를 입력해주세요.'];
-	else if (value.length < 8) return ['error', '비밀번호를 8자 이상 입력해주세요.'];
+	if (empty) return ['error', ERROR_MASSAGES.empty];
+	else if (value.length < 8) return ['error', ERROR_MASSAGES.invalidFormat];
 	else return ['', ''];
 }

--- a/assets/js/sign/validate/input/validatePasswordCheck.js
+++ b/assets/js/sign/validate/input/validatePasswordCheck.js
@@ -1,6 +1,10 @@
+const ERROR_MASSAGES = {
+	notEqual: '비밀번호가 일치하지 않습니다.',
+};
+
 /** 비밀번호 확인 유효성 검사 */
 export default function validatePasswordCheck({ value, form }) {
 	const password = form.querySelector(`input[name='password']`);
-	if (value !== password.value) return ['error', '비밀번호가 일치하지 않습니다.'];
+	if (value !== password.value) return ['error', ERROR_MASSAGES.notEqual];
 	else return ['', ''];
 }

--- a/assets/js/sign/validate/validate.js
+++ b/assets/js/sign/validate/validate.js
@@ -19,8 +19,7 @@ export default function validateForm({ target, currentTarget: form }) {
 		const errClsNm = 'error';
 		changeInputState(target, state, msg, errClsNm);
 
-		/** form 의 input 들의 value 값이 하나라도 undefined 거나 빈값이면 disabled 활성화 */
-		const formState = [...form.querySelectorAll('input')].some(({ value, classList }) => value === undefined || value === '' || classList.contains(errClsNm));
-		submitButton.disabled = formState;
+		/** 유효성 검사에 따라 submit 버튼 disabled 옵션 토글 */
+		submitButton.disabled = [...form.querySelectorAll('input')].some(({ value, classList }) => value === undefined || value === '' || classList.contains(errClsNm));
 	}
 }

--- a/assets/js/sign/validate/validate.js
+++ b/assets/js/sign/validate/validate.js
@@ -8,7 +8,7 @@ export default function validateForm({ target, currentTarget: form }) {
 	if (target.tagName === 'INPUT') {
 		const { name: page } = submitButton; // 페이지 내 버튼의 name 속성으로 로그인, 회원가입 페이지 확인
 		const { name, value } = target; // input의 name, value
-		const empty = value === undefined || value === ''; // 값이 비었는지 확인
+		const empty = isEmpty(value); // 값이 비었는지 확인
 
 		/** 유효성 검사 */
 		let result;

--- a/assets/js/sign/validate/validate.js
+++ b/assets/js/sign/validate/validate.js
@@ -1,3 +1,4 @@
+import { isEmpty } from '../../isEmpty.js';
 import { submitButton } from '../tags.js';
 import changeInputState from '../../changeInputState.js';
 import valitateLogin from './page/validateLogin.js';
@@ -16,6 +17,7 @@ export default function validateForm({ target, currentTarget: form }) {
 		else if (page === 'sign') result = valitateSign({ name, empty, value, form });
 		const [state, msg] = result;
 
+		/** 에러 상태 관리 */
 		const errClsNm = 'error';
 		changeInputState(target, state, msg, errClsNm);
 

--- a/assets/js/user.js
+++ b/assets/js/user.js
@@ -2,8 +2,8 @@ import { userForm, visibilityButtons } from './sign/tags.js';
 import toggleInputVisibility from './sign/visibility.js';
 import validateForm from './sign/validate/validate.js';
 
-visibilityButtons.forEach((button) => {
+visibilityButtons?.forEach((button) => {
 	button.addEventListener('click', toggleInputVisibility);
 });
 
-userForm.addEventListener('focusout', validateForm);
+userForm?.addEventListener('focusout', validateForm);


### PR DESCRIPTION
## 요구사항

### 기본

`sprint4`

**로그인**

-   [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
-   [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
-   [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
-   [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
-   [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
-   [x] input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
-   [x] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다

**회원가입**

-   [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
-   [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
-   [x] 닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “닉네임을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
-   [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
-   [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
-   [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않습니다..” 에러 메세지를 보입니다.
-   [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘회원가입’ 버튼은 비활성화 됩니다.
-   [x] input 에 유효한 값을 입력하면 ‘회원가입' 버튼이 활성화 됩니다.
-   [x] 활성화된 ‘회원가입’ 버튼을 누르면 “/signup” 로 이동합니다

### 심화

`sprint4`

-   [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
-   [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.

## 주요 변경사항

-   [x] 함수 모듈 세분화

## 지난 리뷰 요구사항

-   [x] CSS 파일의 잘못 선언된 변수 수정
-   [x] 명확하고 의미있는 함수명으로 수정하기
-   [x] 오류메세지 상수로 관리하기
-   [x] 함수를 작은 단위로 독립하기
-   [ ] 반복되는 유효성 검사 로직 재활용하기

## Netlify 주소

[Netlify Link](https://juhyeokc-sprint4.netlify.app)

## 스크린샷

<img width="1800" alt="스크린샷 2024-04-24 15 38 49" src="https://github.com/codeit-bootcamp-frontend/7-Sprint-Mission/assets/55866765/89d8bc02-79ef-40b7-a398-4b4134dd5f21">

## 멘토에게

-   다양한 로직을 가진 검사 모듈을 만드는데 어려움이 있습니다.
